### PR TITLE
Handle POLLERR and POLLHUP in eizo_dbg_poll

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -378,7 +378,7 @@ eizo_dbg_poll(struct eizo_handle *handle)
         } else if (pfds[0].revents & POLLERR) {
           fprintf(stderr, "%s: communication error (POLLERR)\n", __func__);
           return -1;
-        } else if (pfds[0].events & POLLHUP) {
+        } else if (pfds[0].revents & POLLHUP) {
           fprintf(stderr, "%s: communication error (POLLHUP)\n", __func__);
           return -1;
         }

--- a/src/debug.c
+++ b/src/debug.c
@@ -375,6 +375,12 @@ eizo_dbg_poll(struct eizo_handle *handle)
             } else {
                 fprintf(stderr, "%s: read < 7\n", __func__);
             }
+        } else if (pfds[0].revents & POLLERR) {
+          fprintf(stderr, "%s: communication error (POLLERR)\n", __func__);
+          return -1;
+        } else if (pfds[0].events & POLLHUP) {
+          fprintf(stderr, "%s: communication error (POLLHUP)\n", __func__);
+          return -1;
         }
     }
 


### PR DESCRIPTION
When poll results in POLLERR or POLLHUP, rather than POLLIN, eizo_dbg_poll goes into an infinite loop and uses 100% CPU. This condition can be induced by changing the input source on EV2740X (in KVM mode) from DisplayPort (where the polling computer is) to USB-C. To be specific, doing that leads to POLLERR.
This change causes the tool to exit gracefully if this happens.

I don't know what the best approach would be here long term (e.g. if the polling should be automatically restarted after some timeout when this happens).